### PR TITLE
fix: autocompletion not triggering after quote character

### DIFF
--- a/lua/cmp_emoji/init.lua
+++ b/lua/cmp_emoji/init.lua
@@ -14,7 +14,7 @@ source.get_trigger_characters = function()
   return { ":" }
 end
 source.get_keyword_pattern = function()
-  return [=[\%(\s\|^\)\zs:[[:alnum:]_\-\+]*:\?]=]
+  return [=[\%([[:space:]"'`]\|^\)\zs:[[:alnum:]_\-\+]*:\?]=]
 end
 
 ---creates the datastructure for cmp source


### PR DESCRIPTION
Thanks for this plugin! Since `cmp-emoji` is basically unmaintained, it's nice to see someone else providing a cmp emoji source.

Unfortunately, it seems this plugin is using the same regex pattern as `cmp-emoji`, and therefore also inherits this bug: https://github.com/hrsh7th/cmp-emoji/issues/2

This PR fixes that issue by triggering auto-completion after `space` *or* a quote character.