### PR TITLE
Added config to lazy README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ With [Lazy.nvim](https://github.com/folke/lazy.nvim):
     -- is not vim.fn.stdpath("data") .. "/lazy/
     plugin_path = vim.fn.expand("$HOME/plugins/"),
   },
+  config = function(_, opts)
+    require("emoji").setup(opts)
+    -- optional for telescope integration
+    require("telescope").load_extension("emoji")
+  end,
 }
 ```
 


### PR DESCRIPTION
Not including `config = function(_, opts)` and `require("emoji").setup(opts)` created an either/or situation with cmp_integration and telescope. If the config is provided with the default\* `config = function()` + telescope registration, it wouldn't run the plugin's internal setup function which means the cmp source wouldn't be registered.

\* Idk if it's *really* the default, this is the first time I've seen anything other than

This is the config I originally tried:
```lua
{
    "allaman/emoji.nvim",
    ft = "markdown",
    dependencies = {
        "hrsh7th/nvim-cmp",
        "nvim-telescope/telescope.nvim",
    },
    opts = {
        enable_cmp_integration = true,
    },
    config = function()
        require("telescope").load_extension("emoji")
        vim.keymap.set("n", "<leader>fe", function()
            vim.cmd(":Telescope emoji")
        end)
    end,
},
```

> Sorry for the minuscule pull request and thank you for having your nvim config on github cause this was really bugging me

