### PR TITLE
Adding an easy keymap for kickstart.nvim telescope users

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ With [Lazy.nvim](https://github.com/folke/lazy.nvim):
     require("emoji").setup(opts)
     -- optional for telescope integration
     local ts = require('telescope').load_extension 'emoji'
-    -- optional keymap for existing kickstart.nvim users
     vim.keymap.set('n', '<leader>se', ts.emoji, { desc = '[S]earch [E]moji' })
   end,
 }

--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ With [Lazy.nvim](https://github.com/folke/lazy.nvim):
   config = function(_, opts)
     require("emoji").setup(opts)
     -- optional for telescope integration
-    require("telescope").load_extension("emoji")
+    local ts = require('telescope').load_extension 'emoji'
+    -- optional keymap for existing kickstart.nvim users
+    vim.keymap.set('n', '<leader>se', ts.emoji, { desc = '[S]earch [E]moji' })
   end,
 }
 ```


### PR DESCRIPTION
As a kickstart.nvim user, the first thing I did is add a telescope keybind `<leader>se` to activate the Emoji.nvim telescope ui.

## kickstart.nvim's `lua.init`
```lua
...
  --  Uncomment the following line and add your plugins to `lua/custom/plugins/*.lua` to get going.
  --    For additional information, see `:help lazy.nvim-lazy.nvim-structuring-your-plugins`
  { import = 'custom.plugins' },
...
```

## `~/.config/nvim/lua/custom/plugins/emoji.lua`
```lua
return {
  {
    'allaman/emoji.nvim',
    dependencies = {
      -- optional for nvim-cmp integration
      'hrsh7th/nvim-cmp',
      -- optional for telescope integration
      'nvim-telescope/telescope.nvim',
    },
    opts = {
      -- default is false
      enable_cmp_integration = true,
      -- optional if your plugin installation directory
      -- is not vim.fn.stdpath("data") .. "/lazy/
      -- plugin_path = vim.fn.expand '$HOME/plugins/',
    },
    config = function(_, opts)
      require('emoji').setup(opts)
      -- optional for telescope integration
      local ts = require('telescope').load_extension 'emoji'
      vim.keymap.set('n', '<leader>se', ts.emoji, { desc = '[S]earch [E]moji' })
    end,
  },
}
```